### PR TITLE
Bump version on tests

### DIFF
--- a/test/install.bats
+++ b/test/install.bats
@@ -21,9 +21,9 @@ teardown() {
 @test "install" {
   # Random early version that doesn't look too special.
   # Won't work on arm64, tho :/
-  run asdf install gh 0.4.0
+  run asdf install gh 0.10.0
   [ "$status" -eq 0 ]
-  echo "$output" | grep "Downloading gh version 0.4.0"
+  echo "$output" | grep "Downloading gh version 0.10.0"
 }
 
 @test "install latest" {
@@ -35,6 +35,5 @@ teardown() {
 @test "list all gh" {
   run asdf list all gh
   [ "$status" -eq 0 ]
-  echo "$output" | grep "0.4.0"
-  echo "$output" | grep "0.6.2"
+  echo "$output" | grep "0.10.0"
 }


### PR DESCRIPTION
The releases API only returns 30 entries. We could paginate, but I don't feel like doing that in bash. So, I'm just fixing the failing test for another 30 releases.